### PR TITLE
avatar/name columns option

### DIFF
--- a/config/filament-latex.php
+++ b/config/filament-latex.php
@@ -22,4 +22,5 @@ return [
     'parser' => '/usr/bin/pdflatex', // The latex parser to use. Options: pdflatex, xelatex, lualatex (pdflatex is the default).
     'compilation-timeout' => 60, // The maximum time in seconds to wait for the compilation to finish.
     'strict-compilation' => false, // Options: strict, non-strict. Strict mode will throw exceptions on compilation errors, otherwise it will not.
+    'avatar-columns' => false, // If true, the avatar columns will be shown instead of the names of the author and collaborators.
 ];

--- a/src/Models/FilamentLatex.php
+++ b/src/Models/FilamentLatex.php
@@ -4,6 +4,7 @@ namespace TheThunderTurner\FilamentLatex\Models;
 
 use Exception;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 /**
  * @property int $id
@@ -28,7 +29,7 @@ class FilamentLatex extends Model
     /**
      * @throws Exception
      */
-    public function author(): \Illuminate\Database\Eloquent\Relations\BelongsTo
+    public function author(): BelongsTo
     {
         return $this->BelongsTo($this->getUserModel(), 'author_id');
     }

--- a/src/Resources/FilamentLatexResource.php
+++ b/src/Resources/FilamentLatexResource.php
@@ -98,8 +98,9 @@ class FilamentLatexResource extends Resource
                     ->dateTime(),
                 TextColumn::make('created_at')
                     ->dateTime(),
-                ImageColumn::make('author')
+                ImageColumn::make('author_avatar')
                     ->label('Author')
+                    ->visible(config('filament-latex.avatar-columns'))
                     ->circular()
                     ->tooltip(function ($record) use ($userModel) {
                         return $userModel::find($record->author_id)->name;
@@ -107,13 +108,28 @@ class FilamentLatexResource extends Resource
                     ->getStateUsing(function ($record) use ($userModel) {
                         return $userModel::find($record->author_id)->avatar_url;
                     }),
-                ImageColumn::make('collaborators')
+                ImageColumn::make('collaborators_avatars')
+                    ->label('Collaborators')
+                    ->visible(config('filament-latex.avatar-columns'))
                     ->circular()
                     ->stacked()
                     ->limit(3)
                     ->limitedRemainingText()
                     ->getStateUsing(function ($record) use ($userModel) {
                         return $userModel::whereIn('id', $record->collaborators_id)->pluck('avatar_url')->toArray();
+                    }),
+                TextColumn::make('author.name')
+                    ->label('Author')
+                    ->visible(! config('filament-latex.avatar-columns'))
+                    ->badge()
+                    ->color('info'),
+                TextColumn::make('collaborators')
+                    ->label('Collaborators')
+                    ->visible(! config('filament-latex.avatar-columns'))
+                    ->badge()
+                    ->color('info')
+                    ->getStateUsing(function ($record) use ($userModel) {
+                        return $userModel::whereIn('id', $record->collaborators_id)->pluck('name')->toArray();
                     }),
                 TextColumn::make('updated_at')
                     ->label('Last Updated')


### PR DESCRIPTION
This pull request includes changes to the `filament-latex` configuration and model files to support displaying author and collaborator avatars conditionally. The most important changes are as follows:

Configuration updates:

* [`config/filament-latex.php`](diffhunk://#diff-b4b9eafead68b8c505ccbcb79822d885e6eee35e79f9b99fb0780df398de280dR25): Added a new configuration option `avatar-columns` to control the display of author and collaborator avatars.

Model updates:

* [`src/Models/FilamentLatex.php`](diffhunk://#diff-de0069d8134e42308a506abe1cf9c96150e9b36d0846952b1b26e0a6bc6f1b49R7): Added the `BelongsTo` import and updated the `author` method to use the imported `BelongsTo` type. [[1]](diffhunk://#diff-de0069d8134e42308a506abe1cf9c96150e9b36d0846952b1b26e0a6bc6f1b49R7) [[2]](diffhunk://#diff-de0069d8134e42308a506abe1cf9c96150e9b36d0846952b1b26e0a6bc6f1b49L31-R32)

Resource updates:

* [`src/Resources/FilamentLatexResource.php`](diffhunk://#diff-411723ede7a53782c198351e1ce0b10a9f357704d1afd68937eb349cb41433f5L101-R133): Modified the table columns to conditionally display avatar images or names based on the `avatar-columns` configuration. This includes changes to the `author` and `collaborators` columns, as well as adding new columns for `author.name` and `collaborators`.

Closes:
#25