### PR TITLE
Feature/fix last tex file

### DIFF
--- a/resources/views/components/latex-index.blade.php
+++ b/resources/views/components/latex-index.blade.php
@@ -28,7 +28,8 @@
             @if ($pdfUrl)
                 <iframe
                     x-data="{ pdfUrl: @js($pdfUrl) }"
-                    x-on:document-compiled.window="pdfUrl"
+                    {{-- '?' + new Date().getTime() is a hack that allows for refresh upon compilation --}}
+                    x-on:document-compiled.window="pdfUrl = @js($pdfUrl) + '?' + new Date().getTime()"
                     class="h-screen w-full"
                     :src="pdfUrl"
                 ></iframe>

--- a/resources/views/components/latex-index.blade.php
+++ b/resources/views/components/latex-index.blade.php
@@ -29,6 +29,7 @@
                 <iframe
                     x-data="{ pdfUrl: @js($pdfUrl) }"
                     {{-- '?' + new Date().getTime() is a hack that allows for refresh upon compilation --}}
+                    {{-- New timestamp forces broswer to listen to new query, bypassing caching issues (Not sure if there is a better way) --}}
                     x-on:document-compiled.window="pdfUrl = @js($pdfUrl) + '?' + new Date().getTime()"
                     class="h-screen w-full"
                     :src="pdfUrl"

--- a/src/Concerns/CanUploadFiles.php
+++ b/src/Concerns/CanUploadFiles.php
@@ -2,11 +2,8 @@
 
 namespace TheThunderTurner\FilamentLatex\Concerns;
 
-use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\FileUpload;
-use Filament\Notifications\Notification;
-use Illuminate\Support\Str;
 
 trait CanUploadFiles
 {

--- a/src/Concerns/CanUploadFiles.php
+++ b/src/Concerns/CanUploadFiles.php
@@ -2,11 +2,16 @@
 
 namespace TheThunderTurner\FilamentLatex\Concerns;
 
+use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\FileUpload;
+use Filament\Notifications\Notification;
+use Illuminate\Support\Str;
 
 trait CanUploadFiles
 {
+    use Utils;
+
     /**
      * Uploads a file.
      */
@@ -41,19 +46,7 @@ trait CanUploadFiles
             ->color('danger')
             ->requiresConfirmation()
             ->action(function ($arguments) {
-                return $this->getStorage()->delete($this->filamentLatex->id . '/files/' . $arguments['file']);
+                return $this->canDeleteFile($arguments);
             });
-    }
-
-    /**
-     * Returns an array of files that have been
-     * uploaded.
-     *
-     * All files are uploaded in files/ directory. In the future
-     * we could add subdirectories for better organization.
-     */
-    public function getFiles(): array
-    {
-        return array_map('basename', $this->getStorage()->files($this->filamentLatex->id . '/files'));
     }
 }

--- a/src/Concerns/CanUseDocument.php
+++ b/src/Concerns/CanUseDocument.php
@@ -4,7 +4,6 @@ namespace TheThunderTurner\FilamentLatex\Concerns;
 
 use Exception;
 use Filament\Notifications\Notification;
-use Illuminate\Contracts\Filesystem\Filesystem;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Process;
 use Illuminate\Support\Facades\Storage;
@@ -19,10 +18,7 @@ use TheThunderTurner\FilamentLatex\Models\FilamentLatex;
  */
 trait CanUseDocument
 {
-    public function getStorage(): Filesystem
-    {
-        return Storage::disk(config('filament-latex.storage'));
-    }
+    use Utils;
 
     /**
      * We pass the content as an argument.

--- a/src/Concerns/Utils.php
+++ b/src/Concerns/Utils.php
@@ -2,11 +2,18 @@
 
 namespace TheThunderTurner\FilamentLatex\Concerns;
 
+use Exception;
 use Filament\Notifications\Notification;
 use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use TheThunderTurner\FilamentLatex\Models\FilamentLatex;
 
+/**
+ * @property FilamentLatex $filamentLatex
+ * @property string $latexContent
+ */
 trait Utils
 {
     /**
@@ -47,5 +54,19 @@ trait Utils
         } else {
             return $this->getStorage()->delete($this->filamentLatex->id . '/files/' . $arguments['file']);
         }
+    }
+
+    /**
+     * @throws Exception
+     */
+    public function getUserModel(): string
+    {
+        $userModel = config('filament-latex.user-model');
+
+        if (! $userModel || ! class_exists($userModel) || ! is_subclass_of($userModel, Model::class)) {
+            throw new Exception('User model is not set or is not a valid Eloquent model class');
+        }
+
+        return $userModel;
     }
 }

--- a/src/Concerns/Utils.php
+++ b/src/Concerns/Utils.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace TheThunderTurner\FilamentLatex\Concerns;
+
+use Filament\Notifications\Notification;
+use Illuminate\Contracts\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+trait Utils
+{
+    /**
+     * Returns an array of files that have been
+     * uploaded.
+     *
+     * All files are uploaded in files/ directory. In the future
+     * we could add subdirectories for better organization.
+     */
+    public function getFiles(): array
+    {
+        return array_map('basename', $this->getStorage()->files($this->filamentLatex->id . '/files'));
+    }
+
+    /**
+     * Returns the storage disk.
+     */
+    public function getStorage(): Filesystem
+    {
+        return Storage::disk(config('filament-latex.storage'));
+    }
+
+    /**
+     * Checks if file can be deleted. It is extremely important that
+     * the check is done here and not in the blade file as input data
+     * can be manipulated!!
+     */
+    public function canDeleteFile(array $arguments): bool
+    {
+        $texFiles = collect($this->getFiles())->filter(fn ($file) => Str::endsWith($file, '.tex'));
+        if ($texFiles->count() === 1) {
+            Notification::make()
+                ->title('You cannot delete the only ".tex" file in the project.')
+                ->color('danger')
+                ->send();
+
+            return false;
+        } else {
+            return $this->getStorage()->delete($this->filamentLatex->id . '/files/' . $arguments['file']);
+        }
+    }
+}

--- a/src/Models/FilamentLatex.php
+++ b/src/Models/FilamentLatex.php
@@ -5,6 +5,7 @@ namespace TheThunderTurner\FilamentLatex\Models;
 use Exception;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use TheThunderTurner\FilamentLatex\Concerns\Utils;
 
 /**
  * @property int $id
@@ -16,6 +17,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class FilamentLatex extends Model
 {
+    use Utils;
+
     protected $fillable = ['name', 'content', 'attachment', 'attachment_file_names', 'deadline', 'author_id', 'collaborators_id'];
 
     protected $table = 'filament-latex';
@@ -32,19 +35,5 @@ class FilamentLatex extends Model
     public function author(): BelongsTo
     {
         return $this->BelongsTo($this->getUserModel(), 'author_id');
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function getUserModel(): string
-    {
-        $userModel = config('filament-latex.user-model');
-
-        if (! $userModel || ! class_exists($userModel) || ! is_subclass_of($userModel, Model::class)) {
-            throw new Exception('User model is not set or is not a valid Eloquent model class');
-        }
-
-        return $userModel;
     }
 }


### PR DESCRIPTION
This pull request includes several changes to improve file handling and utility functions in the `filament-latex` package. The most important changes include the introduction of a new `Utils` trait, refactoring of existing methods to use this trait, and an update to the `iframe` element to address caching issues.

### Introduction of `Utils` Trait:
* [`src/Concerns/Utils.php`](diffhunk://#diff-7064a3fb977fea9b541a044b6118ab598c9de35e1804d3818823891c869b2c63R1-R72): Added a new `Utils` trait that includes methods for file handling, storage retrieval, and user model validation.

### Refactoring to Use `Utils` Trait:
* [`src/Concerns/CanUploadFiles.php`](diffhunk://#diff-fd7bd83b53a8cd27cc416b3e90d1b0bc669e46953aa7c99f7a00361f5ea75597R10-R11): Added the `Utils` trait and refactored the `deleteAction` method to use `canDeleteFile` from the `Utils` trait. [[1]](diffhunk://#diff-fd7bd83b53a8cd27cc416b3e90d1b0bc669e46953aa7c99f7a00361f5ea75597R10-R11) [[2]](diffhunk://#diff-fd7bd83b53a8cd27cc416b3e90d1b0bc669e46953aa7c99f7a00361f5ea75597L44-L58)
* [`src/Concerns/CanUseDocument.php`](diffhunk://#diff-22908ae1a220c5e2246b9d376ac0e54c612a20a72500ed4c1051ddab1d69de2bL7): Added the `Utils` trait and removed the `getStorage` method, which is now part of the `Utils` trait. [[1]](diffhunk://#diff-22908ae1a220c5e2246b9d376ac0e54c612a20a72500ed4c1051ddab1d69de2bL7) [[2]](diffhunk://#diff-22908ae1a220c5e2246b9d376ac0e54c612a20a72500ed4c1051ddab1d69de2bL22-R21)
* [`src/Models/FilamentLatex.php`](diffhunk://#diff-de0069d8134e42308a506abe1cf9c96150e9b36d0846952b1b26e0a6bc6f1b49R8): Added the `Utils` trait and removed the `getUserModel` method, which is now part of the `Utils` trait. [[1]](diffhunk://#diff-de0069d8134e42308a506abe1cf9c96150e9b36d0846952b1b26e0a6bc6f1b49R8) [[2]](diffhunk://#diff-de0069d8134e42308a506abe1cf9c96150e9b36d0846952b1b26e0a6bc6f1b49R20-R21) [[3]](diffhunk://#diff-de0069d8134e42308a506abe1cf9c96150e9b36d0846952b1b26e0a6bc6f1b49L36-L49)

### Update to `iframe` Element:
* [`resources/views/components/latex-index.blade.php`](diffhunk://#diff-abb97a4a8a70c735838aad8663cb305626211e724fb4de54e3abc247dc23d24aL31-R33): Updated the `iframe` element to append a timestamp to the `pdfUrl` to bypass caching issues upon document compilation.

Closes:
#44 